### PR TITLE
Wrap Callback functions if LibError is present to ensure errors are not lost

### DIFF
--- a/GeminiGUI.lua
+++ b/GeminiGUI.lua
@@ -377,7 +377,7 @@ end
 
 function Control:GetChild(strName)
   for _, child in ipairs(self.children) do
-    if child.options and child.Name and child.options.Name == strName then
+    if child.options and child.options.Name and child.options.Name == strName then
       return child
     end
   end

--- a/GeminiGUI.lua
+++ b/GeminiGUI.lua
@@ -374,6 +374,13 @@ function Control:AddChild(tChild)
   table.insert(self.children, tChild)
 end
 
+local function WrapCallback(func)
+  if Apollo.GetPackage("Gemini:LibError-1.0") and Apollo.GetPackage("Gemini:LibError-1.0").tPackage then
+    return function(...) local a = arg; xpcall(function() func(unpack(a)) end, Apollo.GetPackage("Gemini:LibError-1.0").tPackage.Error) end
+  end
+  return func
+end
+
 -- Add an event handler to the widget prototype
 -- @param strName The event name to be handled
 -- @param strFunction (Optional) The function name on the event handler table
@@ -383,7 +390,7 @@ end
 -- @usage myPrototype:AddEvent("ButtonSignal", function() Print("Clicked!") end) -- when the event is fired, the anonymous function will be called
 function Control:AddEvent(strName, strFunction, fnInline)
   if type(strFunction) == "function" then
-    fnInline = strFunction
+    fnInline = WrapCallback(strFunction)
     strFunction = "On" .. strName .. tostring(fnInline):gsub("function: ", "_")
   end
   


### PR DESCRIPTION
This works... not sure I'm happy with it though so any feedback is welcome! I did think about passing in the reference to the Error handler, but there didn't seem to be a convenient place to store it... Also is there a good place we could cache the reference to it?

Also not sure if there is a better way to wrap the function... sat here for a good while trying to get the ... passed through the inner function but this is the best I could think up..
